### PR TITLE
chg:dev:support loading only the declared openstack modules using an …

### DIFF
--- a/osclients.py
+++ b/osclients.py
@@ -31,12 +31,24 @@ from keystoneclient import session
 from keystoneclient.v2_0 import client as keystonev2
 from keystoneclient.v3 import client as keystonev3
 
-from neutronclient.v2_0 import client as neutronclient
-from novaclient import client as novaclient
-from cinderclient.v2 import client as cinderclient
-from glanceclient import client as glanceclient
-from swiftclient import client as swiftclient
-
+if 'OSCLIENTS_MODULES' not in env:
+    from neutronclient.v2_0 import client as neutronclient
+    from novaclient import client as novaclient
+    from cinderclient.v2 import client as cinderclient
+    from glanceclient import client as glanceclient
+    from swiftclient import client as swiftclient
+else:
+    modules = set(mod.strip() for mod in env['OSCLIENTS_MODULES'].split(','))
+    if 'neutron' in modules:
+        from neutronclient.v2_0 import client as neutronclient
+    if 'nova' in modules:
+        from novaclient import client as novaclient
+    if 'cinder' in modules:
+        from cinderclient.v2 import client as cinderclient
+    if 'glance' in modules:
+        from glanceclient import client as glanceclient
+    if 'swift' in modules:
+        from swiftclient import client as swiftclient
 
 class OpenStackClients(object):
     """This class provides methods to obtains several openstack clients,


### PR DESCRIPTION
#### Reviewers
@flopezag @jframos @pratid
 
#### Description
Load OpenStack modules dynamically

This change pretends to avoid  dependencies in other projects that use this class (e.g. glancesync) but only need some modules. For example, if a project does not use cinder nor swift, these dependencies are not longer required.

The solution is a new optional parameter in the constructor: modules. It may contain a list of module names, the keyword 'all' or the keyword 'auto' (the default). When modules=auto, the modules are loaded on demand, that is, when invoking a get_*client() method. Using modules="all" or modules and an explicit list, make more easy to detect the required modules.

#### Testing
None