### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/docker/AcceptanceTests/Dockerfile
+++ b/docker/AcceptanceTests/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu
 ENV GIT_REV develop
-RUN apt-get update && apt-get -y install python-pip python-dev \
+RUN apt-get update && apt-get --no-install-recommends -y install python-pip python-dev \
   libmysqlclient-dev libpq-dev \
   libxml2-dev libxslt1-dev git \
   libffi-dev zip python-mysqldb 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install  mysql-server
+RUN DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -y install  mysql-server
 RUN pip install --upgrade pip; pip install git+https://github.com/telefonicaid/fiware-skuld@${GIT_REV}
 RUN git clone https://github.com/telefonicaid/fiware-skuld/ /opt/fiware-skuld/
 WORKDIR /opt/fiware-skuld

--- a/docker/UnitTests/Dockerfile
+++ b/docker/UnitTests/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu
 ENV GIT_REV develop
-RUN apt-get update &&  apt-get -y install python-pip python-dev \
+RUN apt-get update &&  apt-get --no-install-recommends -y install python-pip python-dev \
   libmysqlclient-dev libpq-dev \
   libxml2-dev libxslt1-dev git \
   libffi-dev zip python-mysqldb 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install  mysql-server
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends  mysql-server
 RUN git clone https://github.com/telefonicaid/fiware-skuld/ /opt/fiware-skuld/
 WORKDIR /opt/fiware-skuld/
 RUN git checkout ${GIT_REV}


### PR DESCRIPTION

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .